### PR TITLE
Prevent bot2human from eating colon

### DIFF
--- a/weechat_bot2human.py
+++ b/weechat_bot2human.py
@@ -145,7 +145,7 @@ def msg_cb(data, modifier, modifier_data, string):
     else:
         return string
 
-    return ":{host} {command} {channel} {text}".format(**parsed)
+    return ":{host} {command} {channel} :{text}".format(**parsed)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
 This is pointed out by @MaskRay. WeeChat expects a colon before text.
