### PR TITLE
bot2human: add nicks into a group

### DIFF
--- a/weechat_bot2human.py
+++ b/weechat_bot2human.py
@@ -25,6 +25,7 @@
 #
 
 # Changelog:
+# 0.3.0: Add relayed nicks into nicklist, enabling completion
 # 0.2.2: Support ZNC timestamp
 # 0.2.1: Color filtering only applies on nicknames
 #        More than 3 nick rules can be defined
@@ -37,9 +38,9 @@ import weechat as w
 import re
 
 SCRIPT_NAME = "bot2human"
-SCRIPT_AUTHOR = "Justin Wong & Hexchain"
+SCRIPT_AUTHOR = "Justin Wong & Hexchain & quietlynn"
 SCRIPT_DESC = "Replace IRC message nicknames with regex match from chat text"
-SCRIPT_VERSION = "0.2.2"
+SCRIPT_VERSION = "0.3.0"
 SCRIPT_LICENSE = "GPLv3"
 
 DEFAULTS = {


### PR DESCRIPTION
This addresses the problems caused by #6 by adding the relayed nicks into a group called `bot2human`. See discussion on #6 for details.

Restarting WeeChat is highly recommended after applying the update.
Reloading the script and then rejoining every channel should also work.
